### PR TITLE
subblocks count correction

### DIFF
--- a/modes.h
+++ b/modes.h
@@ -68,7 +68,7 @@ void cnt_crypt(u32 *buff, u64 size, struct gost_ctx_t *ctx)
 {
 	u64 i;
 
-	u64 subblocks = (size + size % 8) / 4;
+	u64 subblocks = size / 4 + !!(size % 4);
 
 	if (ctx->mac) {
 		if (ctx->encrypt) {
@@ -108,7 +108,7 @@ void cfb_crypt(u32 *buff, u64 size, struct gost_ctx_t *ctx)
 {
 	u64 i;
 
-	u64 subblocks = (size + size % 8) / 4;
+	u64 subblocks = size / 4 + !!(size % 4);
 
 	if (ctx->encrypt) {
 		if (ctx->mac) {


### PR DESCRIPTION
Subblocks for cnt and cbf modes were calculated in such way that data with 1 byte length did not crypted at all.